### PR TITLE
facilitate integration into rspec test suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ Gems that are up-to-date are colored green and gems that are out-of-date but wit
 
 Gemsurance exits with code 0 if there are no gems with reported vulnerabilities and code 1 if there are any such gems.
 
+### Integration into a Rails RSpec suite
+Running the gemsurance check as part of your RSpec test suite will cause an RSpec failure whenever a gem with a known vulnerability is detected in your application. This is incredibly useful if your application is tested regularly by a CI build. You can set this up by adding sample_spec/gemsurance_spec.rb to your RSpec tests.
+
 ### Command-line options
 Command-line options to the gemsurance executable are as follows:
 - --pre: Consider pre-release gem versions

--- a/sample_spec/gemsurance_spec.rb
+++ b/sample_spec/gemsurance_spec.rb
@@ -1,0 +1,8 @@
+require 'spec_helper'
+
+describe 'Check for vulnerabilities in Ruby gems' do
+  specify 'Return value of gemsurance call should be zero' do
+    `bundle exec gemsurance`
+    $?.to_i.zero?.should be_true, "One or more of your Ruby gems has a known security vulnerability. Check #{Rails.root}/gemsurance_report.html for more info."
+  end
+end


### PR DESCRIPTION
Hi there,

thank you for this useful gem :). We've found that incorporating these kinds of tests into our rspec coverage is often the easiest way to incorporate such checks into an existing CI build process. The code here is nothing special, it just facilitates setting up such a thing as much as possible.
