### PR TITLE
Add feature '--output file' CLI option

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Running the gemsurance check as part of your RSpec test suite will cause an RSpe
 ### Command-line options
 Command-line options to the gemsurance executable are as follows:
 - --pre: Consider pre-release gem versions
+- --output FILE: Output report to specified file
 
 ## TODOs
 - Add CSV formatter

--- a/bin/gemsurance
+++ b/bin/gemsurance
@@ -1,31 +1,7 @@
 #!/usr/bin/env ruby
 
 require 'gemsurance'
-require 'optparse'
+require 'gemsurance/cli'
 
-options = {}
-
-opts = OptionParser.new do |opts|
-  opts.banner = "Usage: gemsurance [options]"
-
-  opts.separator ""
-  opts.separator "Options:"
-
-  opts.on("--pre", "Consider pre-release gem versions") do |lib|
-    options[:pre] = true
-  end
-
-  opts.on_tail("-h", "--help", "Show this help") do
-    puts opts
-    exit
-  end
-
-  opts.on_tail("--version", "Show version") do
-    puts "Gemsurance version #{Gemsurance::VERSION}"
-    exit
-  end
-end
-
-opts.parse!(ARGV)
-
+options = Gemsurance::Cli.parse(ARGV)
 Gemsurance::Runner.new(options).run

--- a/lib/gemsurance/cli.rb
+++ b/lib/gemsurance/cli.rb
@@ -1,0 +1,40 @@
+require 'optparse'
+
+module Gemsurance
+  class Cli
+    class << self
+      def parse(*argv)
+
+        options = {}
+
+        opts = OptionParser.new do |opts|
+          opts.banner = "Usage: gemsurance [options]"
+
+          opts.separator ""
+          opts.separator "Options:"
+
+          opts.on("--pre", "Consider pre-release gem versions") do |lib|
+            options[:pre] = true
+          end
+
+          opts.on("--output FILE", "Output report to given file") do |file|
+            options[:output_file] = file
+          end
+
+          opts.on_tail("-h", "--help", "Show this help") do
+            puts opts
+            exit
+          end
+
+          opts.on_tail("--version", "Show version") do
+            puts "Gemsurance version #{Gemsurance::VERSION}"
+            exit
+          end
+        end
+
+        opts.parse!(argv)
+        options
+      end
+    end
+  end
+end

--- a/test/unit/cli_test.rb
+++ b/test/unit/cli_test.rb
@@ -1,0 +1,27 @@
+require 'helper'
+require 'gemsurance/cli'
+
+class CliTest < Test::Unit::TestCase
+
+  def test_default_options
+    options = Gemsurance::Cli.parse
+    assert_equal ({}), options
+  end
+
+  def test_option_pre
+    options = Gemsurance::Cli.parse('--pre')
+    assert_equal true, options[:pre]
+  end
+
+  def test_option_output_with_arg
+    options = Gemsurance::Cli.parse('--output', 'file.html')
+    assert_equal 'file.html', options[:output_file]
+  end
+
+  def test_option_output_without_arg
+    assert_raise OptionParser::MissingArgument do
+      Gemsurance::Cli.parse('--output')
+    end
+  end
+
+end

--- a/test/unit/runner_test.rb
+++ b/test/unit/runner_test.rb
@@ -3,6 +3,16 @@ require 'helper'
 class RunnerTest < Test::Unit::TestCase
   # TODO add integration test
 
+  def test_output_file_option_default
+    runner = Gemsurance::Runner.new
+    assert_equal 'gemsurance_report.html', runner.instance_variable_get(:@output_file)
+  end
+
+  def test_output_file_option_custom
+    runner = Gemsurance::Runner.new(:output_file => 'custom.html')
+    assert_equal 'custom.html', runner.instance_variable_get(:@output_file)
+  end
+
   def test_add_vulnerability_data
     runner = Gemsurance::Runner.new
     gem_infos = [


### PR DESCRIPTION
This request has two changes.

1) It moves the OptParser logic into it's own method so that it can be tested.
2) It adds support for a command line option "--output file" to specify an alternate output file.

Tests included. Readme updated.

Thanks!
