### PR TITLE
Feature: Add links to gem's homepage, source code, and documentation if they exist.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
 pkg
 tmp
+gemsurance_report.html

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,11 +3,13 @@ PATH
   specs:
     gemsurance (0.1.4)
       bundler (~> 1.2)
+      gems (~> 0.8)
       git (~> 1.2)
 
 GEM
   remote: https://rubygems.org/
   specs:
+    gems (0.8.3)
     git (1.2.6)
     metaclass (0.0.1)
     mocha (0.14.0)

--- a/gemsurance.gemspec
+++ b/gemsurance.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency("bundler", "~> 1.2")
   s.add_dependency("git", "~> 1.2")
+  s.add_dependency("gems", "~> 0.8")
   
   s.add_development_dependency("mocha", "0.14.0")
   s.add_development_dependency("rake", "0.9.2.2")

--- a/lib/gemsurance.rb
+++ b/lib/gemsurance.rb
@@ -1,6 +1,7 @@
 require 'bundler'
 require 'git'
 require 'erb'
+require 'gems'
 
 require 'gemsurance/gem_info_retriever'
 require 'gemsurance/html_formatter'

--- a/lib/gemsurance/gem_info_retriever.rb
+++ b/lib/gemsurance/gem_info_retriever.rb
@@ -5,14 +5,19 @@ module Gemsurance
       STATUS_CURRENT    = 'current'
       STATUS_VULNERABLE = 'vulnerable'
       
-      attr_reader :name, :current_version, :newest_version, :vulnerabilities
+      attr_reader :name, :current_version, :newest_version, :vulnerabilities,
+                  :homepage_uri, :source_code_uri, :documentation_uri
       
-      def initialize(name, current_version, newest_version, status = STATUS_CURRENT)
+      def initialize(name, current_version, newest_version, homepage_uri, source_code_uri, documentation_uri, status = STATUS_CURRENT)
         @name = name
         @current_version = current_version
         @newest_version = newest_version
+        @homepage_uri = homepage_uri
+        @documentation_uri = documentation_uri
+        @source_code_uri = source_code_uri
         @status = status
         @vulnerabilities = []
+        
       end
       
       def add_vulnerability!(vulnerability)
@@ -62,13 +67,18 @@ module Gemsurance
         gem_outdated = Gem::Version.new(active_spec.version) > Gem::Version.new(current_spec.version)
         git_outdated = current_spec.git_version != active_spec.git_version
 
+        info = ::Gems.info(active_spec.name)
+        homepage_uri      = info['homepage_uri']
+        documentation_uri = info['documentation_uri']
+        source_code_uri   = info['source_code_uri']
+
         # TODO: handle git versions
         # spec_version    = "#{active_spec.version}#{active_spec.git_version}"
         # current_version = "#{current_spec.version}#{current_spec.git_version}"
         if gem_outdated || git_outdated
-          gem_infos << GemInfo.new(active_spec.name, current_spec.version, active_spec.version, GemInfo::STATUS_OUTDATED)
+          gem_infos << GemInfo.new(active_spec.name, current_spec.version, active_spec.version, homepage_uri, documentation_uri, source_code_uri, GemInfo::STATUS_OUTDATED)
         else
-          gem_infos << GemInfo.new(active_spec.name, current_spec.version, current_spec.version)
+          gem_infos << GemInfo.new(active_spec.name, current_spec.version, current_spec.version, homepage_uri, documentation_uri, source_code_uri)
         end
       end
       gem_infos

--- a/lib/gemsurance/templates/output.html.erb
+++ b/lib/gemsurance/templates/output.html.erb
@@ -734,6 +734,18 @@
       margin: 0 auto;
       width: 980px;
     }
+
+    a.link {
+      display: inline-block;
+      width: 16px;
+      height: 16px;
+    }
+
+    /* Images are from http://ionicons.com: home, code, document */
+    a.link.homepage_uri { background: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAMAAAAoLQ9TAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAAVFBMVEUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD///8UXluqAAAAGnRSTlMABANvWfBB4i3SHb4RpwJw7heQ4H+PHOMPH4aZIH0AAAABYktHRBsCYNSkAAAAaUlEQVQY032MWQ6AIAwFQQRXNkHRd/+DqghRYnQ+ms4kLSEfUFp6xVhVhJrz+umiARpxe9vhoGuz9wMiQ3/5KJGQ4+lKmxyMVmewE8Cd48BkVbzxwLwsM+DTUx9X/xN0CDrPyLpta55vdqg9CJWGTyKrAAAAJXRFWHRkYXRlOmNyZWF0ZQAyMDE0LTAyLTE0VDE1OjEzOjM0LTA4OjAwwk+TXgAAACV0RVh0ZGF0ZTptb2RpZnkAMjAxNC0wMi0xNFQxNToxMzozNC0wODowMLMSK+IAAAAASUVORK5CYII="); }
+    a.link.source_code_uri { background: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQBAMAAADt3eJSAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAAKlBMVEUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD///8KreiaAAAADXRSTlMAF1gKCxSknQmjoKkTWOJM+wAAAAFiS0dEDfa0YfUAAAA1SURBVAjXY2AgCjAqOwmAGWEV7akgmnVaAGtmAJDRtYeB4fQKZAbrzAAgQlbMwKgC1U4QAAC8eg1ZB0rLqAAAACV0RVh0ZGF0ZTpjcmVhdGUAMjAxNC0wMi0xNFQxNToxMzoxMS0wODowMNJSu4QAAAAldEVYdGRhdGU6bW9kaWZ5ADIwMTQtMDItMTRUMTU6MTM6MTEtMDg6MDCjDwM4AAAAAElFTkSuQmCC"); }
+    a.link.documentation_uri { background: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAMAAAAoLQ9TAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAAe1BMVEUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD///+9xjqiAAAAKHRSTlMABhweElzPwdDFM3+XICOI5b4pgIZ5krZuypbsd7yFlR8bj1vSYwcIhjGo+AAAAAFiS0dEKL2wtbIAAABfSURBVBjTY2DAAhiZmIGABSHAysbOzs7ByQUX4Obh5ePlFxAUggkIiwAJUTFucWZkAQlJKWkZZAEmCRlZOWQBJJoqAtzyTApAoKgEE1DmYAcDFVWogJoCHxjwqmPzOgD1bAZ9iN52VAAAACV0RVh0ZGF0ZTpjcmVhdGUAMjAxNC0wMi0xNFQxNToxOTozNy0wODowMOSFGQoAAAAldEVYdGRhdGU6bW9kaWZ5ADIwMTQtMDItMTRUMTU6MTk6MzctMDg6MDCV2KG2AAAAAElFTkSuQmCC"); }
+
   </style>
 </head>
 <body>
@@ -747,6 +759,7 @@
           <th>Newest Version</th>
           <th>Status</th>
           <th>Detailed Status</th>
+          <th>Links</th>
         </tr>
       </thead>
       <tbody>
@@ -793,6 +806,17 @@
                   <% end %>
                 <% end %>
               </div>
+            </td>
+            <td>
+              <% unless gem_info.homepage_uri.to_s.empty? %>
+                <a href="<%= gem_info.homepage_uri %>" target="_blank" class="link homepage_uri" title="Homepage"></a>
+              <% end %>
+              <% unless gem_info.source_code_uri.to_s.empty? %>
+                <a href="<%= gem_info.source_code_uri %>" target="_blank" class="link source_code_uri" title="Source"></a>
+              <% end %>
+              <% unless gem_info.documentation_uri.to_s.empty? %>
+                <a href="<%= gem_info.documentation_uri %>" target="_blank" class="link documentation_uri" title="Docs"></a>
+              <% end %>
             </td>
           </tr>
         <% end %>

--- a/test/unit/gem_info_retriever_test.rb
+++ b/test/unit/gem_info_retriever_test.rb
@@ -3,7 +3,7 @@ require 'helper'
 module Gemsurance
   class GemInfoRetrieverTest < Test::Unit::TestCase
     def test_gem_info_functionality
-      current_gem_info = GemInfoRetriever::GemInfo.new('current_gem', Gem::Version.new('3.0.2'), Gem::Version.new('3.0.2'))
+      current_gem_info = GemInfoRetriever::GemInfo.new('current_gem', Gem::Version.new('3.0.2'), Gem::Version.new('3.0.2'), nil, nil, nil)
       assert current_gem_info.current?
       assert ! current_gem_info.outdated?
       assert ! current_gem_info.vulnerable?
@@ -12,7 +12,7 @@ module Gemsurance
       assert_equal Gem::Version.new('3.0.2'), current_gem_info.newest_version
       assert_equal [], current_gem_info.vulnerabilities
 
-      outdated_gem_info = GemInfoRetriever::GemInfo.new('old_gem', Gem::Version.new('2.0.7'), Gem::Version.new('5.1.2'), GemInfoRetriever::GemInfo::STATUS_OUTDATED)
+      outdated_gem_info = GemInfoRetriever::GemInfo.new('old_gem', Gem::Version.new('2.0.7'), Gem::Version.new('5.1.2'), nil, nil, nil, GemInfoRetriever::GemInfo::STATUS_OUTDATED)
       assert ! outdated_gem_info.current?
       assert outdated_gem_info.outdated?
       assert ! outdated_gem_info.vulnerable?
@@ -21,7 +21,7 @@ module Gemsurance
       assert_equal Gem::Version.new('5.1.2'), outdated_gem_info.newest_version
       assert_equal [], outdated_gem_info.vulnerabilities
 
-      vulnerable_gem_info = GemInfoRetriever::GemInfo.new('vulnerable_gem', Gem::Version.new('4.5.3'), Gem::Version.new('4.5.4'), GemInfoRetriever::GemInfo::STATUS_VULNERABLE)
+      vulnerable_gem_info = GemInfoRetriever::GemInfo.new('vulnerable_gem', Gem::Version.new('4.5.3'), Gem::Version.new('4.5.4'), nil, nil, nil, GemInfoRetriever::GemInfo::STATUS_VULNERABLE)
       vulnerability = Vulnerability.new(vulnerability_yaml)
       vulnerable_gem_info.add_vulnerability!(vulnerability)
       assert ! vulnerable_gem_info.current?
@@ -33,29 +33,36 @@ module Gemsurance
       assert_equal [vulnerability], vulnerable_gem_info.vulnerabilities
     end
 
+    def test_gem_info_uris
+      current_gem_info = GemInfoRetriever::GemInfo.new('current_gem', Gem::Version.new('3.0.2'), Gem::Version.new('3.0.2'), 'http://homepage.com', 'http://source.com', 'http://documentation.com')
+      assert_equal 'http://homepage.com', current_gem_info.homepage_uri
+      assert_equal 'http://source.com', current_gem_info.source_code_uri
+      assert_equal 'http://documentation.com', current_gem_info.documentation_uri
+    end
+
     def test_gem_info_equality
       vulnerability = Vulnerability.new(vulnerability_yaml)
-      gem_info_1 = GemInfoRetriever::GemInfo.new('vulnerable_gem', Gem::Version.new('1.2.3'), Gem::Version.new('4.5.6'), GemInfoRetriever::GemInfo::STATUS_VULNERABLE)
+      gem_info_1 = GemInfoRetriever::GemInfo.new('vulnerable_gem', Gem::Version.new('1.2.3'), Gem::Version.new('4.5.6'), nil, nil, nil, GemInfoRetriever::GemInfo::STATUS_VULNERABLE)
       gem_info_1.add_vulnerability!(vulnerability)
 
-      gem_info_2 = GemInfoRetriever::GemInfo.new('vulnerable_gem', Gem::Version.new('1.2.3'), Gem::Version.new('4.5.6'), GemInfoRetriever::GemInfo::STATUS_VULNERABLE)
+      gem_info_2 = GemInfoRetriever::GemInfo.new('vulnerable_gem', Gem::Version.new('1.2.3'), Gem::Version.new('4.5.6'), nil, nil, nil, GemInfoRetriever::GemInfo::STATUS_VULNERABLE)
       gem_info_2.add_vulnerability!(vulnerability)
 
       assert_equal gem_info_1, gem_info_2
 
-      gem_info_3 = GemInfoRetriever::GemInfo.new('vulnerable_gem', Gem::Version.new('1.2.3'), Gem::Version.new('4.5.6'), GemInfoRetriever::GemInfo::STATUS_VULNERABLE)
+      gem_info_3 = GemInfoRetriever::GemInfo.new('vulnerable_gem', Gem::Version.new('1.2.3'), Gem::Version.new('4.5.6'), nil, nil, nil, GemInfoRetriever::GemInfo::STATUS_VULNERABLE)
       assert_not_equal gem_info_2, gem_info_3
 
-      gem_info_4 = GemInfoRetriever::GemInfo.new('foo', Gem::Version.new('1.2.3'), Gem::Version.new('4.5.6'), GemInfoRetriever::GemInfo::STATUS_VULNERABLE)
+      gem_info_4 = GemInfoRetriever::GemInfo.new('foo', Gem::Version.new('1.2.3'), Gem::Version.new('4.5.6'), nil, nil, nil, GemInfoRetriever::GemInfo::STATUS_VULNERABLE)
       assert_not_equal gem_info_2, gem_info_4
 
-      gem_info_5 = GemInfoRetriever::GemInfo.new('vulnerable_gem', Gem::Version.new('1.2.4'), Gem::Version.new('4.5.6'), GemInfoRetriever::GemInfo::STATUS_VULNERABLE)
+      gem_info_5 = GemInfoRetriever::GemInfo.new('vulnerable_gem', Gem::Version.new('1.2.4'), Gem::Version.new('4.5.6'), nil, nil, nil, GemInfoRetriever::GemInfo::STATUS_VULNERABLE)
       assert_not_equal gem_info_2, gem_info_5
 
-      gem_info_6 = GemInfoRetriever::GemInfo.new('vulnerable_gem', Gem::Version.new('1.2.3'), Gem::Version.new('4.5.7'), GemInfoRetriever::GemInfo::STATUS_VULNERABLE)
+      gem_info_6 = GemInfoRetriever::GemInfo.new('vulnerable_gem', Gem::Version.new('1.2.3'), Gem::Version.new('4.5.7'), nil, nil, nil, GemInfoRetriever::GemInfo::STATUS_VULNERABLE)
       assert_not_equal gem_info_2, gem_info_6
 
-      gem_info_7 = GemInfoRetriever::GemInfo.new('vulnerable_gem', Gem::Version.new('1.2.3'), Gem::Version.new('4.5.6'), GemInfoRetriever::GemInfo::STATUS_CURRENT)
+      gem_info_7 = GemInfoRetriever::GemInfo.new('vulnerable_gem', Gem::Version.new('1.2.3'), Gem::Version.new('4.5.6'), nil, nil, nil, GemInfoRetriever::GemInfo::STATUS_CURRENT)
       assert_not_equal gem_info_2, gem_info_7
     end
 
@@ -78,14 +85,14 @@ module Gemsurance
       retriever = GemInfoRetriever.new(current_specs, definition_mock)
       gems = retriever.retrieve
       assert_equal [
-        GemInfoRetriever::GemInfo.new('rake', Gem::Version.new('0.9.2.2'), Gem::Version.new('10.0.2'), GemInfoRetriever::GemInfo::STATUS_OUTDATED),
-        GemInfoRetriever::GemInfo.new('bundler', Gem::Version.new('1.3.5'), Gem::Version.new('1.3.5'), GemInfoRetriever::GemInfo::STATUS_CURRENT)
+        GemInfoRetriever::GemInfo.new('rake', Gem::Version.new('0.9.2.2'), Gem::Version.new('10.0.2'), nil, nil, nil, GemInfoRetriever::GemInfo::STATUS_OUTDATED),
+        GemInfoRetriever::GemInfo.new('bundler', Gem::Version.new('1.3.5'), Gem::Version.new('1.3.5'), nil, nil, nil, GemInfoRetriever::GemInfo::STATUS_CURRENT)
       ], gems
 
       gems_with_prerelease = retriever.retrieve(:pre => true)
       assert_equal [
-        GemInfoRetriever::GemInfo.new('rake', Gem::Version.new('0.9.2.2'), Gem::Version.new('10.0.3pre'), GemInfoRetriever::GemInfo::STATUS_OUTDATED),
-        GemInfoRetriever::GemInfo.new('bundler', Gem::Version.new('1.3.5'), Gem::Version.new('1.3.6pre'), GemInfoRetriever::GemInfo::STATUS_OUTDATED)
+        GemInfoRetriever::GemInfo.new('rake', Gem::Version.new('0.9.2.2'), Gem::Version.new('10.0.3pre'), nil, nil, nil, GemInfoRetriever::GemInfo::STATUS_OUTDATED),
+        GemInfoRetriever::GemInfo.new('bundler', Gem::Version.new('1.3.5'), Gem::Version.new('1.3.6pre'), nil, nil, nil, GemInfoRetriever::GemInfo::STATUS_OUTDATED)
       ], gems_with_prerelease
     end
 

--- a/test/unit/html_formatter_test.rb
+++ b/test/unit/html_formatter_test.rb
@@ -4,10 +4,10 @@ module Gemsurance
   class HtmlFormatterTest < Test::Unit::TestCase
     def test_format
       gem_infos = [
-        GemInfoRetriever::GemInfo.new('sweet', Gem::Version.new('1.2.3'), Gem::Version.new('1.2.3')),
-        GemInfoRetriever::GemInfo.new('cool', Gem::Version.new('2.3.4'), Gem::Version.new('2.3.5'), GemInfoRetriever::GemInfo::STATUS_OUTDATED)
+        GemInfoRetriever::GemInfo.new('sweet', Gem::Version.new('1.2.3'), Gem::Version.new('1.2.3'), 'http://homepage.com', 'http://source.com', 'http://documentation.com'),
+        GemInfoRetriever::GemInfo.new('cool', Gem::Version.new('2.3.4'), Gem::Version.new('2.3.5'), nil, nil, nil, GemInfoRetriever::GemInfo::STATUS_OUTDATED)
       ]
-      vulnerable_gem = GemInfoRetriever::GemInfo.new('dangerous', Gem::Version.new('8.4.7'), Gem::Version.new('8.4.8'), GemInfoRetriever::GemInfo::STATUS_VULNERABLE)
+      vulnerable_gem = GemInfoRetriever::GemInfo.new('dangerous', Gem::Version.new('8.4.7'), Gem::Version.new('8.4.8'), nil, nil, nil, GemInfoRetriever::GemInfo::STATUS_VULNERABLE)
       vulnerable_gem.add_vulnerability!(Vulnerability.new(vulnerability_yaml))
       gem_infos << vulnerable_gem
       actual_html = HtmlFormatter.new(gem_infos).format
@@ -50,7 +50,7 @@ YAML
 
     def expected_html
 <<-HTML
-  <div class="wrapper">
+<div class="wrapper">
     <h1>Gemsurance Report</h1>
     <table class="table">
       <thead>
@@ -60,6 +60,7 @@ YAML
           <th>Newest Version</th>
           <th>Status</th>
           <th>Detailed Status</th>
+          <th>Links</th>
         </tr>
       </thead>
       <tbody>
@@ -78,6 +79,11 @@ YAML
               <div style="width:200px">
                 
               </div>
+            </td>
+            <td>
+              
+              
+              
             </td>
           </tr>
         
@@ -104,11 +110,16 @@ Remote Code Execution
                       <dt>URL</dt>
                       <dd><a href="http://osvdb.org/show/osvdb/89026">More Info</a></dd>
                       <dt>Patched Versions</dt>
-                      <dd>~> 2.3.15, ~> 3.0.19, ~> 3.1.10, >= 3.2.11</dd>
+                      <dd>~&gt; 2.3.15, ~&gt; 3.0.19, ~&gt; 3.1.10, &gt;= 3.2.11</dd>
                     </dl>
                   
                 
               </div>
+            </td>
+            <td>
+              
+              
+              
             </td>
           </tr>
         
@@ -126,6 +137,17 @@ Remote Code Execution
               <div style="width:200px">
                 
               </div>
+            </td>
+            <td>
+              
+                <a href="http://homepage.com" target="_blank" class="link homepage_uri" title="Homepage"></a>
+              
+              
+                <a href="http://source.com" target="_blank" class="link source_code_uri" title="Source"></a>
+              
+              
+                <a href="http://documentation.com" target="_blank" class="link documentation_uri" title="Docs"></a>
+              
             </td>
           </tr>
         

--- a/test/unit/runner_test.rb
+++ b/test/unit/runner_test.rb
@@ -10,6 +10,9 @@ class RunnerTest < Test::Unit::TestCase
         'actionpack',
         Gem::Version.new('3.2.14'),
         Gem::Version.new('4.0.2'),
+        'http://homepage.com',
+        'http://source.com',
+        'http://documentation.com',
         Gemsurance::GemInfoRetriever::GemInfo::STATUS_OUTDATED
       )
     ]


### PR DESCRIPTION
I added code to pull the gem's homepage, source code, and documentation urls from rubygems.org if they exist and display them using icons from ionic framework in a new column in the table.  

I found myself pulling up homepages to read the changelogs of my out of date gems.  This should make that easier.

![links](https://f.cloud.github.com/assets/16705/2176534/6d87145a-95d6-11e3-8ced-91e1414f5321.png)
