### PR TITLE
Fixed command options

### DIFF
--- a/bin/gemsurance
+++ b/bin/gemsurance
@@ -3,5 +3,5 @@
 require 'gemsurance'
 require 'gemsurance/cli'
 
-options = Gemsurance::Cli.parse(ARGV)
+options = Gemsurance::Cli.parse(*ARGV)
 Gemsurance::Runner.new(options).run


### PR DESCRIPTION
Since 0.3.0 (I guess) command options don't work.
Fixed with a splat operator on `ARGV`, otherwise `ARGV` becomes an array of array in `Gemsurance::Cli.parse`