### PR TITLE
Added a public method to the Runner class to build gems infos

### DIFF
--- a/bin/gemsurance
+++ b/bin/gemsurance
@@ -4,4 +4,4 @@ require 'gemsurance'
 require 'gemsurance/cli'
 
 options = Gemsurance::Cli.parse(*ARGV)
-Gemsurance::Runner.new(options).run
+Gemsurance::Runner.new(options).run.report

--- a/test/unit/runner_test.rb
+++ b/test/unit/runner_test.rb
@@ -13,13 +13,58 @@ class RunnerTest < Test::Unit::TestCase
     assert_equal 'custom.html', runner.instance_variable_get(:@output_file)
   end
 
+  def test_report_without_previous_run
+    stubs_puts
+
+    runner = Gemsurance::Runner.new
+    assert_raise SystemExit do
+      runner.report
+    end
+  end
+
+  def test_report_with_vulnerabilities
+    runner = Gemsurance::Runner.new
+
+    vulnerable_gem = Gemsurance::GemInfoRetriever::GemInfo.new(
+      'actionpack',
+      Gem::Version.new('3.2.14'),
+      Gem::Version.new('4.0.2'),
+      true,
+      'http://homepage.com',
+      'http://source.com',
+      'http://documentation.com',
+      Gemsurance::GemInfoRetriever::GemInfo::STATUS_VULNERABLE
+    )
+
+    runner.instance_variable_set(:@gem_infos_loaded, true)
+    runner.instance_variable_set(:@gem_infos, [vulnerable_gem])
+    runner.expects(:generate_report).returns(true)
+
+    assert_raise SystemExit do
+      runner.report
+    end
+  end
+
+  def test_report_without_vulnerabilities
+    runner = Gemsurance::Runner.new
+
+    runner.instance_variable_set(:@gem_infos_loaded, true)
+    runner.instance_variable_set(:@gem_infos, [])
+    runner.expects(:generate_report).returns(true)
+
+    runner.report
+  end
+
   def test_add_vulnerability_data
+    stubs_puts
+
     runner = Gemsurance::Runner.new
     gem_infos = [
       Gemsurance::GemInfoRetriever::GemInfo.new(
         'actionpack',
         Gem::Version.new('3.2.14'),
         Gem::Version.new('4.0.2'),
+        true,
         'http://homepage.com',
         'http://source.com',
         'http://documentation.com',
@@ -27,11 +72,18 @@ class RunnerTest < Test::Unit::TestCase
       )
     ]
 
-    runner.send(:add_vulnerability_data, gem_infos, './test/unit/vulnerabilities/gems')
+    runner.instance_variable_set(:@gem_infos, gem_infos)
+    runner.send(:add_vulnerability_data, './test/unit/vulnerabilities/gems')
 
     updated_gem_info = gem_infos.first
     assert updated_gem_info.vulnerable?
     expected_vulnerability_yml = File.read(File.join(File.dirname(__FILE__), 'vulnerabilities/gems/actionpack/vulnerability2.yml'))
     assert_equal [Gemsurance::Vulnerability.new(expected_vulnerability_yml)], updated_gem_info.vulnerabilities
+  end
+
+  private
+
+  def stubs_puts
+    Kernel.send(:define_method, :puts) { |*args| "" }
   end
 end


### PR DESCRIPTION
Hi Jon, me again ;)

I've extracted gems infos build into a public method `build_gems_infos`, that sets an instance method `@bundled_gem_infos` (created and used by sub private methods) and returns it.

Thanks to this method, I'm writing a gemsurance_slack gem to send Gemsurance alerts in a Slack channel by calling `my_gems_infos = Gemsurance::Runner.new.build_gems_infos`.

Thx