### PR TITLE
Rely on gem versions from Rubygems API to get outdated gems

### DIFF
--- a/lib/gemsurance/gem_info_retriever.rb
+++ b/lib/gemsurance/gem_info_retriever.rb
@@ -4,10 +4,10 @@ module Gemsurance
       STATUS_OUTDATED   = 'outdated'
       STATUS_CURRENT    = 'current'
       STATUS_VULNERABLE = 'vulnerable'
-      
+
       attr_reader :name, :current_version, :newest_version, :in_gem_file, :vulnerabilities,
                   :homepage_uri, :source_code_uri, :documentation_uri
-      
+
       def initialize(name, current_version, newest_version, in_gem_file, homepage_uri, source_code_uri, documentation_uri, status = STATUS_CURRENT)
         @name = name
         @current_version = current_version
@@ -18,22 +18,22 @@ module Gemsurance
         @source_code_uri = source_code_uri
         @status = status
         @vulnerabilities = []
-        
+
       end
-      
+
       def add_vulnerability!(vulnerability)
         @status = STATUS_VULNERABLE
         @vulnerabilities << vulnerability
       end
-      
+
       def outdated?
         @status == STATUS_OUTDATED
       end
-      
+
       def current?
         @status == STATUS_CURRENT
       end
-      
+
       def vulnerable?
         @status == STATUS_VULNERABLE
       end
@@ -46,42 +46,37 @@ module Gemsurance
           @vulnerabilities == other.vulnerabilities
       end
     end
-    
-    def initialize(specs, dependencies, bundle_definition)
+
+    def initialize(specs, dependencies)
       @specs = specs
       @dependencies = dependencies
-      @bundle_definition = bundle_definition
     end
-    
+
     def retrieve(options = {})
       gem_infos = []
-      
+
       @specs.each do |current_spec|
-        active_spec = @bundle_definition.index[current_spec.name].sort_by { |b| b.version }
+        active_spec = ::Gems.versions(current_spec.name).sort_by { |b| b[:number] }
 
         if !current_spec.version.prerelease? && !options[:pre] && active_spec.size > 1
-          active_spec = active_spec.delete_if { |b| b.respond_to?(:version) && b.version.prerelease? }
+          active_spec = active_spec.delete_if { |b| b[:prerelease] }
         end
 
         active_spec = active_spec.last
         next if active_spec.nil?
 
-        gem_outdated = Gem::Version.new(active_spec.version) > Gem::Version.new(current_spec.version)
-        git_outdated = current_spec.git_version != active_spec.git_version
+        gem_outdated = Gem::Version.new(active_spec[:number]) > Gem::Version.new(current_spec.version)
 
-        info = ::Gems.info(active_spec.name)
+        info = ::Gems.info(current_spec.name)
         homepage_uri      = info['homepage_uri']
         documentation_uri = info['documentation_uri']
         source_code_uri   = info['source_code_uri']
 
-        # TODO: handle git versions
-        # spec_version    = "#{active_spec.version}#{active_spec.git_version}"
-        # current_version = "#{current_spec.version}#{current_spec.git_version}"
-        in_gem_file = @dependencies.any?{|d| d.name == active_spec.name}
-        if gem_outdated || git_outdated
-          gem_infos << GemInfo.new(active_spec.name, current_spec.version, active_spec.version, in_gem_file, homepage_uri, documentation_uri, source_code_uri, GemInfo::STATUS_OUTDATED)
+        in_gem_file = @dependencies.any?{|d| d.name == current_spec.name}
+        if gem_outdated
+          gem_infos << GemInfo.new(current_spec.name, current_spec.version, Gem::Version.new(active_spec[:number]), in_gem_file, homepage_uri, documentation_uri, source_code_uri, GemInfo::STATUS_OUTDATED)
         else
-          gem_infos << GemInfo.new(active_spec.name, current_spec.version, current_spec.version, in_gem_file, homepage_uri, documentation_uri, source_code_uri)
+          gem_infos << GemInfo.new(current_spec.name, current_spec.version, current_spec.version, in_gem_file, homepage_uri, documentation_uri, source_code_uri)
         end
       end
       gem_infos

--- a/lib/gemsurance/runner.rb
+++ b/lib/gemsurance/runner.rb
@@ -38,10 +38,8 @@ module Gemsurance
       bundler = Bundler.load
       current_specs = bundler.specs
       dependencies = bundler.dependencies
-      definition = Bundler.definition(true)
-      definition.resolve_remotely!
 
-      GemInfoRetriever.new(current_specs, dependencies, definition).retrieve(:pre => @options[:pre])
+      GemInfoRetriever.new(current_specs, dependencies).retrieve(:pre => @options[:pre])
     end
 
     def retrieve_vulnerability_data

--- a/test/unit/gem_info_retriever_test.rb
+++ b/test/unit/gem_info_retriever_test.rb
@@ -69,20 +69,27 @@ module Gemsurance
     def test_retrieve
       current_specs = Bundler::SpecSet.new([Gem::Specification.new('rake', '0.9.2.2'),
                                             Gem::Specification.new('bundler', '1.3.5')])
-      index = Bundler::Index.new
-      rake_versions = %w(0.9.2 0.9.2.1 0.9.2.2 10.0.1 10.0.2 10.0.3pre)
-      rake_versions.each do |version|
-        index << Gem::Specification.new('rake', version)
-      end
-      bundler_versions = %w(1.2.3 1.2.4 1.2.5 1.2.6 1.3.0 1.3.3 1.3.5 1.3.6pre)
-      bundler_versions.each do |version|
-        index << Gem::Specification.new('bundler', version)
-      end
 
-      definition_mock = mock
-      definition_mock.stubs(:index).returns(index)
+      ::Gems.stubs(:versions).with('rake').returns([
+        { :number => "0.9.2", :prerelease => false },
+        { :number => "0.9.2.1", :prerelease => false },
+        { :number => "0.9.2.2", :prerelease => false },
+        { :number => "10.0.1", :prerelease => false },
+        { :number => "10.0.2", :prerelease => false },
+        { :number => "10.0.3pre", :prerelease => true }
+      ])
+      ::Gems.stubs(:versions).with('bundler').returns([
+        { :number => "1.2.3", :prerelease => false },
+        { :number => "1.2.4", :prerelease => false },
+        { :number => "1.2.5", :prerelease => false },
+        { :number => "1.2.6", :prerelease => false },
+        { :number => "1.3.0", :prerelease => false },
+        { :number => "1.3.3", :prerelease => false },
+        { :number => "1.3.5", :prerelease => false },
+        { :number => "1.3.6pre", :prerelease => true }
+      ])
 
-      retriever = GemInfoRetriever.new(current_specs, [], definition_mock)
+      retriever = GemInfoRetriever.new(current_specs, [])
       gems = retriever.retrieve
       assert_equal [
         GemInfoRetriever::GemInfo.new('rake', Gem::Version.new('0.9.2.2'), Gem::Version.new('10.0.2'), false, nil, nil, nil, GemInfoRetriever::GemInfo::STATUS_OUTDATED),


### PR DESCRIPTION
Hi Jon,

We can't rely on `Bundler.definition` to check outdated gems because of Bundler frozen setting (`Bundler.settings[:frozen]`).
This setting is set to true if you make a bundle install with `--deployment` option. This is what Heroku does and also some Capistrano recipes.

If this setting is true, the Gemfile is "lock" and this line 
```ruby
Bundler.definition(true).send(:resolve_remotely!)
````
will return an empty array. So no outdated games if I try to daily run Gemsurance from the Heroku scheduler :(

I updated the `retrieve` method to rely on `Gems.versions` command. It works like a charm but unfortunately, there is no `git_version` field here so we can't check anymore if a gem is outdated by git_version. Personally, I dont' really understand what this git_version is and in all my tests with Bundler this field is always set to nil.

Thoughts ?



