### PR TITLE
Temporarily unfrozen Bundler (if needed) to get outdated gems

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ tmp
 gemsurance_report.html
 gemsurance_report.yml
 .DS_Store
+.bundle

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -9,9 +9,12 @@ require 'test/unit'
 require "mocha/setup"
 require 'nokogiri'
 
-Kernel.send(:define_method, :puts) { |*args| "" }
-
 class Test::Unit::TestCase
+
+  def setup
+    $stdout.stubs(:puts)
+  end
+
   def generate_gem_infos
     @gem_infos = [
       Gemsurance::GemInfoRetriever::GemInfo.new('sweet', Gem::Version.new('1.2.3'), Gem::Version.new('1.2.3'), true, 'http://homepage.com', 'http://source.com', 'http://documentation.com'),

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -9,6 +9,8 @@ require 'test/unit'
 require "mocha/setup"
 require 'nokogiri'
 
+Kernel.send(:define_method, :puts) { |*args| "" }
+
 class Test::Unit::TestCase
   def generate_gem_infos
     @gem_infos = [


### PR DESCRIPTION
If Bundler has installed gems with `--deployment` option (e.g. like Heroku), it will be frozen and the method `resolve_remotely!` of `Bundler::Definition` will return an empty array.

To fix that, around `Bundler.definition` tasks, we temporarily unfrozen Bundler.

I've tested on Heroku and it works great.
If you want to test it in local, run `bundle install --deployment`, then run Gemsurance current version >> not outdated gems. Now run this forked Gemsurance version >> some outdated gems :smiley: 

Thoughts ?
