### PR TITLE
Add config file to specify manually patched gems

### DIFF
--- a/lib/gemsurance/cli.rb
+++ b/lib/gemsurance/cli.rb
@@ -21,6 +21,10 @@ module Gemsurance
             options[:output_file] = file
           end
 
+          opts.on("--config FILE", "Read configuration from file. Defaults to .gemsurance.yml") do |file|
+            options[:config_file] = file
+          end
+
           opts.on("--format FORMAT", "Output report to given format (html & yml available). Html by default.") do |format|
             options[:formatter] = format
           end

--- a/lib/gemsurance/runner.rb
+++ b/lib/gemsurance/runner.rb
@@ -5,6 +5,7 @@ module Gemsurance
     def initialize(options = {})
       @formatter   = options.delete(:formatter) || :html
       @output_file = options.delete(:output_file) || "gemsurance_report.#{@formatter}"
+      @config_file = options.delete(:config_file) || ".gemsurance.yml"
       @options     = options
     end
 
@@ -25,6 +26,9 @@ module Gemsurance
 
   private
     def build_gem_infos
+      if File.exists?(@config_file)
+        @config = YAML::load(File.read(@config_file))
+      end
       @gem_infos = retrieve_bundled_gem_infos
       retrieve_vulnerability_data
       add_vulnerability_data
@@ -56,6 +60,7 @@ module Gemsurance
     def add_vulnerability_data(vulnerabilities_directory = './tmp/vulnerabilities/gems')
       puts "Reading vulnerability data..."
 
+
       @gem_infos.each do |gem_info|
         vulnerability_directory = File.join(vulnerabilities_directory, gem_info.name)
         if File.exists?(vulnerability_directory)
@@ -70,8 +75,13 @@ module Gemsurance
 
             current_version_is_affected = (vulnerability.unaffected_versions || []).none?(&current_version_satisfies_requirement)
             current_version_isnt_patched = (vulnerability.patched_versions || []).none?(&current_version_satisfies_requirement)
+            current_version_isnt_patched_manually = if manual_patches = get_manually_patched_versions_for(gem_info.name, vulnerability.cve)
+              (manual_patches || []).none?(&current_version_satisfies_requirement)
+            else
+              true
+            end
 
-            if current_version_is_affected && current_version_isnt_patched
+            if current_version_is_affected && current_version_isnt_patched && current_version_isnt_patched_manually
               gem_info.add_vulnerability!(vulnerability)
             end
           end
@@ -88,6 +98,12 @@ module Gemsurance
         file.puts output_data
       end
       puts "Generated report #{@output_file}."
+    end
+
+    def get_manually_patched_versions_for(gem, cve)
+      if patches = @config && @config['manually_patched_versions']
+        patches[gem] && patches[gem][cve]
+      end
     end
 
     def resolved_definition

--- a/lib/gemsurance/runner.rb
+++ b/lib/gemsurance/runner.rb
@@ -60,7 +60,6 @@ module Gemsurance
     def add_vulnerability_data(vulnerabilities_directory = './tmp/vulnerabilities/gems')
       puts "Reading vulnerability data..."
 
-
       @gem_infos.each do |gem_info|
         vulnerability_directory = File.join(vulnerabilities_directory, gem_info.name)
         if File.exists?(vulnerability_directory)


### PR DESCRIPTION
This adds the ability to specify gems that were patched manually because upgrading wasn't possible.

Take the latest ActiveSupport Vulnerability CVE 2015-3226 for example. Since rails 3.2 is officially no longer supported we had to patch this manually. To ensure the gemsurance test is happy we implemented the feature that was already requested in #11

Here is how the config file (.gemsurance.yml by default) can look like:

``` yml
manually_patched_versions:
  activesupport:
    2015-3226:
      - 3.2.22
```
