### PR TITLE
Adding --fail-outdated option.

### DIFF
--- a/lib/gemsurance/cli.rb
+++ b/lib/gemsurance/cli.rb
@@ -17,6 +17,10 @@ module Gemsurance
             options[:pre] = true
           end
 
+          opts.on("--fail-outdated", "Returns exit code 2 if any gems are outdated") do |lib|
+            options[:fail_outdated] = true
+          end
+
           opts.on("--output FILE", "Output report to given file") do |file|
             options[:output_file] = file
           end

--- a/lib/gemsurance/runner.rb
+++ b/lib/gemsurance/runner.rb
@@ -20,7 +20,11 @@ module Gemsurance
       end
 
       generate_report
-      exit 1 if @gem_infos.any? { |info| info.vulnerable? }
+      if @gem_infos.any? { |info| info.vulnerable? }
+        exit 1
+      elsif @gem_infos.any? { |info| info.outdated? } and @options[:fail_outdated]
+        exit 2
+      end
     end
 
   private

--- a/lib/gemsurance/runner.rb
+++ b/lib/gemsurance/runner.rb
@@ -22,7 +22,7 @@ module Gemsurance
       generate_report
       if @gem_infos.any? { |info| info.vulnerable? }
         exit 1
-      elsif @gem_infos.any? { |info| info.outdated? } and @options[:fail_outdated]
+      elsif @gem_infos.any? { |info| info.outdated? } && @options[:fail_outdated]
         exit 2
       end
     end

--- a/test/unit/cli_test.rb
+++ b/test/unit/cli_test.rb
@@ -13,6 +13,11 @@ class CliTest < Test::Unit::TestCase
     assert_equal true, options[:pre]
   end
 
+  def test_option_fail_outdated
+    options = Gemsurance::Cli.parse('--fail-outdated')
+    assert_equal true, options[:fail_outdated]
+  end
+
   def test_option_output_with_arg
     options = Gemsurance::Cli.parse('--output', 'file.html')
     assert_equal 'file.html', options[:output_file]

--- a/test/unit/runner_test.rb
+++ b/test/unit/runner_test.rb
@@ -43,6 +43,52 @@ class RunnerTest < Test::Unit::TestCase
     end
   end
 
+  def test_report_with_outdated_gem
+    runner = Gemsurance::Runner.new(fail_outdated: true)
+
+    outdated_gem = Gemsurance::GemInfoRetriever::GemInfo.new(
+      'actionpack',
+      Gem::Version.new('3.2.14'),
+      Gem::Version.new('4.0.2'),
+      true,
+      'http://homepage.com',
+      'http://source.com',
+      'http://documentation.com',
+      Gemsurance::GemInfoRetriever::GemInfo::STATUS_OUTDATED
+    )
+
+    runner.instance_variable_set(:@gem_infos_loaded, true)
+    runner.instance_variable_set(:@gem_infos, [outdated_gem])
+    runner.expects(:generate_report).returns(true)
+
+    assert_raise SystemExit do
+      runner.report
+    end
+  end
+
+  def test_report_with_outdated_gem_do_not_fail
+    runner = Gemsurance::Runner.new(fail_outdated: false)
+
+    outdated_gem = Gemsurance::GemInfoRetriever::GemInfo.new(
+      'actionpack',
+      Gem::Version.new('3.2.14'),
+      Gem::Version.new('4.0.2'),
+      true,
+      'http://homepage.com',
+      'http://source.com',
+      'http://documentation.com',
+      Gemsurance::GemInfoRetriever::GemInfo::STATUS_OUTDATED
+    )
+
+    runner.instance_variable_set(:@gem_infos_loaded, true)
+    runner.instance_variable_set(:@gem_infos, [outdated_gem])
+    runner.expects(:generate_report).returns(true)
+
+    assert_nothing_raised do
+      runner.report
+    end
+  end
+
   def test_run_with_not_frozen_bundler
     runner = Gemsurance::Runner.new
     stub_external_calls(runner)


### PR DESCRIPTION
When `--fail-outdated` is included as an option, gemsurance will exit with status code 2.

Tests included and verified.
