### PR TITLE
Update dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,9 @@ before_install:
   - gem install bundler
 
 rvm:
-  - 2.4.1
-  - 2.3.4
-  - 2.2.7
-  - 2.1.10
-  - 2.0.0-p648
-  - 1.9.3
+  - 2.6.0
+  - 2.5.3
+  - 2.4.5
   - ruby-head
 
 matrix:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,9 +12,11 @@ GEM
     gems (0.8.3)
     git (1.3.0)
     metaclass (0.0.4)
+    mini_portile2 (2.4.0)
     mocha (0.14.0)
       metaclass (~> 0.0.1)
-    nokogiri (1.5.9)
+    nokogiri (1.10.0)
+      mini_portile2 (~> 2.4.0)
     power_assert (1.0.2)
     rake (0.9.2.2)
     test-unit (3.0.9)
@@ -26,9 +28,9 @@ PLATFORMS
 DEPENDENCIES
   gemsurance!
   mocha (= 0.14.0)
-  nokogiri (= 1.5.9)
+  nokogiri (= 1.10.0)
   rake (= 0.9.2.2)
   test-unit (= 3.0.9)
 
 BUNDLED WITH
-   1.15.1
+   1.17.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,14 +3,16 @@ PATH
   specs:
     gemsurance (0.9.0)
       bundler (~> 1.2)
-      gems (~> 0.8)
+      gems (>= 0.8)
       git (~> 1.2)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    gems (0.8.3)
-    git (1.3.0)
+    gems (1.1.1)
+      json
+    git (1.5.0)
+    json (2.1.0)
     metaclass (0.0.4)
     mini_portile2 (2.4.0)
     mocha (0.14.0)

--- a/gemsurance.gemspec
+++ b/gemsurance.gemspec
@@ -25,6 +25,6 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency("mocha", "0.14.0")
   s.add_development_dependency("rake", "0.9.2.2")
-  s.add_development_dependency("nokogiri", "1.5.9")
+  s.add_development_dependency("nokogiri", "1.10.0")
   s.add_development_dependency("test-unit", "3.0.9")
 end

--- a/gemsurance.gemspec
+++ b/gemsurance.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency("bundler", "~> 1.2")
   s.add_dependency("git", "~> 1.2")
-  s.add_dependency("gems", "~> 0.8")
+  s.add_dependency("gems", ">= 0.8")
 
   s.add_development_dependency("mocha", "0.14.0")
   s.add_development_dependency("rake", "0.9.2.2")

--- a/gemsurance.gemspec
+++ b/gemsurance.gemspec
@@ -5,7 +5,7 @@ Gem::Specification.new do |s|
   s.name                      = "gemsurance"
   s.version                   = Gemsurance::VERSION
 
-  s.required_ruby_version     = '>= 1.9.3'
+  s.required_ruby_version     = '>= 2.4'
   s.required_rubygems_version = '>= 1.8.11'
   s.authors                   = ["Jon Kessler"]
   s.description               = "Gem vulnerability and version checker"


### PR DESCRIPTION
There was a deprecation warning when running tests locally on an old version of nokogiri, so I bumped that.

Also our team wants to experiment with using a more up to date version of `gems` that leverages the JSON api for rubygems.org so I'm relaxing the version restriction for that dependency.