### PR TITLE
Setup Dependabot to use GitHub private registries

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,16 @@
+---
+version: 2
+registries:
+  ruby-github:
+    type: rubygems-server
+    url: https://rubygems.pkg.github.com/appfolio
+    token: "${{secrets.READ_ONLY_PACKAGES_CCIMU}}"
+updates:
+- package-ecosystem: bundler
+  directory: "/"
+  schedule:
+    interval: daily
+  pull-request-branch-name:
+    separator: "-"
+  registries: "*"
+  open-pull-requests-limit: 0


### PR DESCRIPTION
https://trello.com/c/sAbjY4Wa/91-deploy-distribute-updated-dependabot-configuration